### PR TITLE
override basename

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 modName = OpenMods
 
 # This is a case-sensitive string to identify your mod. Convention is to use lower case.
-modId = OpenModsLibs
+modId = OpenMods
 
 modGroup = openmods
 
@@ -58,3 +58,10 @@ containsMixinsAndOrCoreModOnly = false
 # If enabled, you may use 'shadowImplementation' for dependencies. They will be integrated in your jar. It is your
 # responsibility check the licence and request permission for distribution, if required.
 usesShadowedDependencies = false
+
+# Optional parameter to customize the produced artifacts. Use this to preserver artifact naming when migrating older
+# projects. New projects should not use this parameter.
+customArchiveBaseName = OpenModsLibs
+
+# Optional parameter to prevent the source code from being published
+# noPublishedSources = 


### PR DESCRIPTION
Identify the ModName to match the @Mod but override the base name to match the previous filename

See https://github.com/GTNewHorizons/OpenModsLib/blob/7697273409e6fd5996a13f48909538a953709b9a/src/main/java/openmods/OpenMods.java#L46 and just above

this corrects mcmod.info to match the metadata