### PR TITLE
Allow `-pre` and `-snapshot` versions

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -67,7 +67,7 @@ customArchiveBaseName = OpenModsLibs
 # This can be usefull, if you e.g. only want to allow versions in the form of '1.1.xxx'.
 # The check is ONLY performed if the version is a git tag.
 # Note: the specified string must be escaped, so e.g. 1\\.1\\.\\d+ instead of 1\.1\.\d+
-versionPattern =0\\.10\\.\\d+
+versionPattern =0\\.10\\.\\d+(-pre|-snapshot)?
 
 # Optional parameter to prevent the source code from being published
 # noPublishedSources = 


### PR DESCRIPTION
Now `1.10.X-pre` and `1.10.X-snapshot` are possible.